### PR TITLE
GitHub Actionsで使用する仮想環境を更新

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2


### PR DESCRIPTION
## 背景
GitHub Actionsのワークフローが最近何故か成功してなかった．
ワークフローの`runs-on`でUbuntu 16.04を指定しているが，これがサポート外になってしまっていることが原因であると考えて，修正した．

## やったこと
- Ubuntu 18.04を使用するように修正
  - [ここ](https://github.com/actions/virtual-environments)を見る感じ，おそらく18.04が一番16.04に近いサポートバージョンなのでこれを選択．